### PR TITLE
Add multi-child support, communication gestures, and progressive quiz

### DIFF
--- a/app/(app)/children/[childId]/language/page.tsx
+++ b/app/(app)/children/[childId]/language/page.tsx
@@ -9,8 +9,39 @@ import { BottomNav } from "@/components/bottom-nav";
 interface WordEntry {
   id: string;
   word: string;
+  type: string;
   isPhrase: boolean;
   observedDate: string;
+}
+
+type TabType = "words" | "gestures";
+
+const suggestedWords: { minMonths: number; maxMonths: number; words: string[] }[] = [
+  { minMonths: 0, maxMonths: 5, words: ["mama", "dada", "baba"] },
+  { minMonths: 6, maxMonths: 9, words: ["mama", "dada", "baba", "no", "bye", "hi", "uh-oh"] },
+  { minMonths: 9, maxMonths: 12, words: ["mama", "dada", "ball", "dog", "cat", "no", "bye-bye", "hi", "uh-oh", "more"] },
+  { minMonths: 12, maxMonths: 15, words: ["mama", "dada", "ball", "dog", "cat", "baby", "shoe", "book", "more", "up", "milk", "juice", "water", "bye-bye", "hi", "no", "yes"] },
+  { minMonths: 15, maxMonths: 18, words: ["please", "thank you", "help", "eat", "drink", "go", "car", "truck", "bird", "fish", "tree", "hat", "cup", "spoon", "bath", "bed", "outside", "hot", "cold", "big"] },
+  { minMonths: 18, maxMonths: 24, words: ["mine", "want", "like", "happy", "sad", "run", "jump", "sit", "open", "close", "wash", "draw", "read", "play", "house", "sun", "moon", "rain", "flower", "bear"] },
+  { minMonths: 24, maxMonths: 36, words: ["because", "friend", "school", "color", "sing", "dance", "sleep", "wake up", "breakfast", "lunch", "dinner", "please", "sorry", "share", "gentle", "fast", "slow", "heavy", "light", "funny"] },
+];
+
+const suggestedGestures: { minMonths: number; maxMonths: number; gestures: string[] }[] = [
+  { minMonths: 0, maxMonths: 8, gestures: ["reaching", "grasping", "turning head toward sounds"] },
+  { minMonths: 9, maxMonths: 12, gestures: ["waving bye-bye", "clapping", "pointing", "raising arms to be picked up", "shaking head no"] },
+  { minMonths: 12, maxMonths: 18, gestures: ["blowing kisses", "nodding yes", "pointing to show things", "giving objects when asked", "pushing away unwanted things"] },
+  { minMonths: 18, maxMonths: 24, gestures: ["thumbs up", "shushing", "beckoning come here", "copying adult gestures", "pretend play actions"] },
+  { minMonths: 24, maxMonths: 36, gestures: ["holding up fingers for age", "hugging dolls/stuffed animals", "taking turns in games"] },
+];
+
+function getSuggestionsForAge(ageMonths: number): string[] {
+  const bracket = suggestedWords.find((b) => ageMonths >= b.minMonths && ageMonths <= b.maxMonths);
+  return bracket?.words ?? suggestedWords[suggestedWords.length - 1].words;
+}
+
+function getGesturesForAge(ageMonths: number): string[] {
+  const bracket = suggestedGestures.find((b) => ageMonths >= b.minMonths && ageMonths <= b.maxMonths);
+  return bracket?.gestures ?? suggestedGestures[suggestedGestures.length - 1].gestures;
 }
 
 export default function LanguagePage() {
@@ -18,10 +49,14 @@ export default function LanguagePage() {
   const router = useRouter();
   const childId = params.childId as string;
 
+  const [activeTab, setActiveTab] = useState<TabType>("words");
   const [words, setWords] = useState<WordEntry[]>([]);
+  const [gestures, setGestures] = useState<WordEntry[]>([]);
+  const [ageMonths, setAgeMonths] = useState(12);
   const [loading, setLoading] = useState(true);
   const [showModal, setShowModal] = useState(false);
   const [newWord, setNewWord] = useState("");
+  const [selectedSuggestions, setSelectedSuggestions] = useState<Set<string>>(new Set());
   const [isPhrase, setIsPhrase] = useState(false);
   const [observedDate, setObservedDate] = useState(
     new Date().toISOString().split("T")[0]
@@ -29,39 +64,97 @@ export default function LanguagePage() {
   const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
-    fetchWords();
+    fetchAll();
+    fetch("/api/children")
+      .then((res) => res.json())
+      .then((data) => {
+        const child = data.data?.find((c: { id: string }) => c.id === childId);
+        if (child) {
+          const dob = new Date(child.dateOfBirth + "T00:00:00");
+          const now = new Date();
+          const months = (now.getFullYear() - dob.getFullYear()) * 12 + (now.getMonth() - dob.getMonth());
+          setAgeMonths(Math.max(0, months));
+        }
+      });
   }, [childId]);
 
-  async function fetchWords() {
-    const res = await fetch(`/api/children/${childId}/words`);
-    const data = await res.json();
-    setWords(data.data);
+  async function fetchAll() {
+    const [wordsRes, gesturesRes] = await Promise.all([
+      fetch(`/api/children/${childId}/words?type=word`),
+      fetch(`/api/children/${childId}/words?type=gesture`),
+    ]);
+    const [wordsData, gesturesData] = await Promise.all([wordsRes.json(), gesturesRes.json()]);
+    setWords(wordsData.data ?? []);
+    setGestures(gesturesData.data ?? []);
     setLoading(false);
+  }
+
+  async function handleDelete(itemId: string) {
+    if (activeTab === "words") {
+      setWords((prev) => prev.filter((w) => w.id !== itemId));
+    } else {
+      setGestures((prev) => prev.filter((g) => g.id !== itemId));
+    }
+    await fetch(`/api/children/${childId}/words`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ wordId: itemId }),
+    });
+    router.refresh();
+  }
+
+  function toggleSuggestion(item: string) {
+    setSelectedSuggestions((prev) => {
+      const next = new Set(prev);
+      if (next.has(item)) {
+        next.delete(item);
+      } else {
+        next.add(item);
+      }
+      return next;
+    });
   }
 
   async function handleAdd(e: React.FormEvent) {
     e.preventDefault();
     setSubmitting(true);
 
-    await fetch(`/api/children/${childId}/words`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ word: newWord, isPhrase, observedDate }),
-    });
+    const itemsToAdd: string[] = [...selectedSuggestions];
+    if (newWord.trim()) {
+      itemsToAdd.push(newWord.trim());
+    }
+
+    const type = activeTab === "words" ? "word" : "gesture";
+
+    for (const word of itemsToAdd) {
+      await fetch(`/api/children/${childId}/words`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          word,
+          type,
+          isPhrase: activeTab === "words" ? isPhrase : false,
+          observedDate,
+        }),
+      });
+    }
 
     setNewWord("");
+    setSelectedSuggestions(new Set());
     setIsPhrase(false);
     setShowModal(false);
     setSubmitting(false);
-    await fetchWords();
+    await fetchAll();
     router.refresh();
   }
 
+  const currentItems = activeTab === "words" ? words : gestures;
   const wordCount = words.filter((w) => !w.isPhrase).length;
   const phraseCount = words.filter((w) => w.isPhrase).length;
+  const gestureCount = gestures.length;
 
   // Group by month
-  const grouped = words.reduce(
+  const grouped = currentItems.reduce(
     (acc, w) => {
       const month = w.observedDate.slice(0, 7);
       if (!acc[month]) acc[month] = [];
@@ -73,11 +166,15 @@ export default function LanguagePage() {
 
   const sortedMonths = Object.keys(grouped).sort().reverse();
 
+  const suggestions = activeTab === "words"
+    ? getSuggestionsForAge(ageMonths).filter((s) => !words.some((w) => w.word.toLowerCase() === s.toLowerCase()))
+    : getGesturesForAge(ageMonths).filter((s) => !gestures.some((g) => g.word.toLowerCase() === s.toLowerCase()));
+
   return (
     <main className="min-h-dvh px-6 pt-8 pb-24">
       <div className="mx-auto max-w-sm">
         {/* Header */}
-        <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center justify-between mb-4">
           <div>
             <button
               onClick={() => router.push("/dashboard")}
@@ -86,34 +183,70 @@ export default function LanguagePage() {
               &#8249; Dashboard
             </button>
             <h1 className="font-[family-name:var(--font-heading)] text-3xl text-olive-dark">
-              Words
+              Communication
             </h1>
           </div>
           <button
-            onClick={() => setShowModal(true)}
+            onClick={() => {
+              setSelectedSuggestions(new Set());
+              setNewWord("");
+              setShowModal(true);
+            }}
             className="w-11 h-11 rounded-full bg-terracotta text-white flex items-center justify-center text-xl shadow-[var(--shadow-button)] hover:bg-terracotta-dark transition-all duration-200 cursor-pointer"
           >
             +
           </button>
         </div>
 
-        {/* Summary */}
-        <div className="rounded-[var(--radius-card)] border border-lang-bg bg-lang-bg/30 p-4 mb-6">
-          <p className="font-semibold text-olive-dark">
-            {wordCount} word{wordCount !== 1 ? "s" : ""}
-            {phraseCount > 0 &&
-              ` · ${phraseCount} phrase${phraseCount !== 1 ? "s" : ""}`}
-          </p>
+        {/* Tab switcher */}
+        <div className="flex rounded-[var(--radius-button)] bg-sand-light p-1 mb-6">
+          <button
+            onClick={() => setActiveTab("words")}
+            className={`flex-1 rounded-[calc(var(--radius-button)-4px)] py-2.5 text-sm font-semibold transition-all duration-200 cursor-pointer ${
+              activeTab === "words"
+                ? "bg-warm-white text-olive-dark shadow-sm"
+                : "text-olive-muted hover:text-olive-dark"
+            }`}
+          >
+            Words
+          </button>
+          <button
+            onClick={() => setActiveTab("gestures")}
+            className={`flex-1 rounded-[calc(var(--radius-button)-4px)] py-2.5 text-sm font-semibold transition-all duration-200 cursor-pointer ${
+              activeTab === "gestures"
+                ? "bg-warm-white text-olive-dark shadow-sm"
+                : "text-olive-muted hover:text-olive-dark"
+            }`}
+          >
+            Gestures
+          </button>
         </div>
 
-        {/* Word list */}
+        {/* Summary */}
+        <div className="rounded-[var(--radius-card)] border border-lang-bg bg-lang-bg/30 p-4 mb-6">
+          {activeTab === "words" ? (
+            <p className="font-semibold text-olive-dark">
+              {wordCount} word{wordCount !== 1 ? "s" : ""}
+              {phraseCount > 0 &&
+                ` · ${phraseCount} phrase${phraseCount !== 1 ? "s" : ""}`}
+            </p>
+          ) : (
+            <p className="font-semibold text-olive-dark">
+              {gestureCount} gesture{gestureCount !== 1 ? "s" : ""}
+            </p>
+          )}
+        </div>
+
+        {/* Item list */}
         {loading ? (
           <p className="text-olive-muted text-center">Loading...</p>
-        ) : words.length === 0 ? (
+        ) : currentItems.length === 0 ? (
           <div className="text-center py-12">
-            <p className="text-olive-muted mb-2">No words logged yet</p>
+            <p className="text-olive-muted mb-2">
+              No {activeTab === "words" ? "words" : "gestures"} logged yet
+            </p>
             <p className="text-olive-light text-sm">
-              Tap + to add your child&apos;s first word
+              Tap + to add your child&apos;s first {activeTab === "words" ? "word" : "gesture"}
             </p>
           </div>
         ) : (
@@ -131,24 +264,33 @@ export default function LanguagePage() {
                 {grouped[month].map((w) => (
                   <div
                     key={w.id}
-                    className="flex items-center justify-between py-3 border-b border-sand-light last:border-0"
+                    className="flex items-center justify-between py-3 border-b border-sand-light last:border-0 group"
                   >
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 flex-1 min-w-0">
                       {w.isPhrase && (
-                        <span className="text-xs bg-lang-bg text-lang rounded-full px-2 py-0.5 font-semibold">
+                        <span className="text-xs bg-lang-bg text-lang rounded-full px-2 py-0.5 font-semibold shrink-0">
                           phrase
                         </span>
                       )}
-                      <span className="text-olive-dark font-medium">
+                      <span className="text-olive-dark font-medium truncate">
                         {w.isPhrase ? `"${w.word}"` : w.word}
                       </span>
                     </div>
-                    <span className="text-xs text-olive-muted">
-                      {new Date(w.observedDate + "T00:00:00").toLocaleDateString("en-US", {
-                        month: "short",
-                        day: "numeric",
-                      })}
-                    </span>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <span className="text-xs text-olive-muted">
+                        {new Date(w.observedDate + "T00:00:00").toLocaleDateString("en-US", {
+                          month: "short",
+                          day: "numeric",
+                        })}
+                      </span>
+                      <button
+                        onClick={() => handleDelete(w.id)}
+                        className="w-6 h-6 rounded-full text-olive-light hover:bg-red-50 hover:text-red-500 flex items-center justify-center text-sm transition-colors duration-200 cursor-pointer"
+                        title="Remove"
+                      >
+                        x
+                      </button>
+                    </div>
                   </div>
                 ))}
               </div>
@@ -157,7 +299,7 @@ export default function LanguagePage() {
         )}
       </div>
 
-      {/* Add word modal */}
+      {/* Add modal */}
       {showModal && (
         <div className="fixed inset-0 z-50 flex items-end justify-center">
           <div
@@ -167,31 +309,65 @@ export default function LanguagePage() {
           <div className="relative w-full max-w-sm bg-warm-white rounded-t-[24px] p-6 pb-[calc(1.5rem+env(safe-area-inset-bottom))]">
             <div className="w-10 h-1 bg-sand rounded-full mx-auto mb-4" />
             <h2 className="font-[family-name:var(--font-heading)] text-2xl text-olive-dark mb-4">
-              Add a word
+              Add {activeTab === "words" ? "a word" : "a gesture"}
             </h2>
             <form onSubmit={handleAdd} className="flex flex-col gap-4">
+              {/* Suggested items */}
+              {(activeTab === "gestures" || !isPhrase) && suggestions.length > 0 && (
+                <div>
+                  <p className="text-xs font-bold text-olive-light uppercase tracking-wider mb-2">
+                    Common for this age
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {suggestions.map((item) => (
+                      <button
+                        key={item}
+                        type="button"
+                        onClick={() => toggleSuggestion(item)}
+                        className={`rounded-full px-3 py-1.5 text-sm font-medium transition-all duration-200 cursor-pointer ${
+                          selectedSuggestions.has(item)
+                            ? "bg-terracotta text-white"
+                            : "bg-sand-light text-olive-muted hover:bg-terracotta-light hover:text-terracotta"
+                        }`}
+                      >
+                        {selectedSuggestions.has(item) ? `\u2713 ${item}` : item}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+
               <input
                 type="text"
                 value={newWord}
                 onChange={(e) => setNewWord(e.target.value)}
-                required
-                placeholder={isPhrase ? '"more milk"' : "doggy"}
+                placeholder={
+                  activeTab === "gestures"
+                    ? "Or type a custom gesture..."
+                    : isPhrase
+                      ? '"more milk"'
+                      : "Or type a custom word..."
+                }
                 className="w-full rounded-[var(--radius-input)] border border-sand-light bg-cream px-4 py-3 text-olive-dark placeholder:text-olive-light focus:border-terracotta focus:outline-none focus:ring-2 focus:ring-terracotta/20"
-                autoFocus
               />
 
               <div className="flex items-center gap-3">
-                <button
-                  type="button"
-                  onClick={() => setIsPhrase(!isPhrase)}
-                  className={`rounded-full px-4 py-2 text-sm font-semibold transition-all duration-200 cursor-pointer min-h-[44px] ${
-                    isPhrase
-                      ? "bg-lang text-white"
-                      : "bg-sand-light text-olive-muted"
-                  }`}
-                >
-                  {isPhrase ? "Phrase" : "Single word"}
-                </button>
+                {activeTab === "words" && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setIsPhrase(!isPhrase);
+                      if (!isPhrase) setSelectedSuggestions(new Set());
+                    }}
+                    className={`rounded-full px-4 py-2 text-sm font-semibold transition-all duration-200 cursor-pointer min-h-[44px] ${
+                      isPhrase
+                        ? "bg-lang text-white"
+                        : "bg-sand-light text-olive-muted"
+                    }`}
+                  >
+                    {isPhrase ? "Phrase" : "Single word"}
+                  </button>
+                )}
 
                 <input
                   type="date"
@@ -203,10 +379,14 @@ export default function LanguagePage() {
 
               <button
                 type="submit"
-                disabled={submitting}
+                disabled={submitting || (selectedSuggestions.size === 0 && !newWord.trim())}
                 className="w-full rounded-[var(--radius-button)] bg-terracotta px-6 py-4 font-semibold text-white shadow-[var(--shadow-button)] transition-all duration-200 hover:bg-terracotta-dark disabled:opacity-50 cursor-pointer min-h-[52px]"
               >
-                {submitting ? "Adding..." : "Add"}
+                {submitting
+                  ? "Adding..."
+                  : selectedSuggestions.size > 0
+                    ? `Add ${selectedSuggestions.size + (newWord.trim() ? 1 : 0)} ${activeTab === "words" ? "word" : "gesture"}${selectedSuggestions.size + (newWord.trim() ? 1 : 0) !== 1 ? "s" : ""}`
+                    : "Add"}
               </button>
             </form>
           </div>

--- a/app/(app)/children/[childId]/motor/[category]/page.tsx
+++ b/app/(app)/children/[childId]/motor/[category]/page.tsx
@@ -11,8 +11,6 @@ interface MilestoneRecord {
   status: string;
 }
 
-const statusOptions = ["not_yet", "sometimes", "consistently"] as const;
-
 const statusLabels: Record<string, string> = {
   not_yet: "Not yet",
   sometimes: "Sometimes",
@@ -39,10 +37,13 @@ export default function MotorCategoryPage() {
   const [checklist, setChecklist] = useState<string[]>([]);
   const [statuses, setStatuses] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(true);
+  const [assessMode, setAssessMode] = useState(false);
+  const [assessList, setAssessList] = useState<string[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     async function load() {
-      // Fetch existing milestones
       const res = await fetch(
         `/api/children/${childId}/milestones?category=${category}`
       );
@@ -53,14 +54,11 @@ export default function MotorCategoryPage() {
         existing[m.name] = m.status;
       }
 
-      // Fetch checklist items from the quiz questions to infer what markers exist
-      // We'll use all known markers for this category
       const allNames = new Set<string>();
       for (const m of data.data as MilestoneRecord[]) {
         allNames.add(m.name);
       }
 
-      // Also fetch the full checklist from the API
       const checklistRes = await fetch(
         `/api/children/${childId}/milestones/checklist?category=${category}`
       );
@@ -78,6 +76,8 @@ export default function MotorCategoryPage() {
     load();
   }, [childId, category]);
 
+  const statusOptions = ["not_yet", "sometimes", "consistently"] as const;
+
   async function toggleStatus(name: string) {
     const current = statuses[name] || "not_yet";
     const currentIdx = statusOptions.indexOf(
@@ -94,6 +94,42 @@ export default function MotorCategoryPage() {
     });
   }
 
+  function startAssessment() {
+    const remaining = checklist.filter(
+      (name) => statuses[name] !== "consistently"
+    );
+    setAssessList(remaining);
+    setCurrentIndex(0);
+    setAssessMode(true);
+  }
+
+  async function handleAnswer(name: string, status: string) {
+    setSaving(true);
+    setStatuses((prev) => ({ ...prev, [name]: status }));
+
+    await fetch(`/api/children/${childId}/milestones`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, category, status }),
+    });
+
+    setSaving(false);
+
+    if (currentIndex < assessList.length - 1) {
+      setCurrentIndex(currentIndex + 1);
+    } else {
+      setAssessMode(false);
+      setCurrentIndex(0);
+    }
+  }
+
+  const achievedCount = Object.values(statuses).filter(
+    (s) => s === "consistently"
+  ).length;
+  const sometimesCount = Object.values(statuses).filter(
+    (s) => s === "sometimes"
+  ).length;
+
   return (
     <main className="min-h-dvh px-6 pt-8 pb-24">
       <div className="mx-auto max-w-sm">
@@ -108,9 +144,6 @@ export default function MotorCategoryPage() {
           <h1 className="font-[family-name:var(--font-heading)] text-3xl text-olive-dark">
             {categoryLabels[category] || category}
           </h1>
-          <p className="text-olive-muted text-sm mt-1">
-            Tap to cycle: Not yet → Sometimes → Consistently
-          </p>
         </div>
 
         {/* Switch between gross/fine */}
@@ -118,9 +151,10 @@ export default function MotorCategoryPage() {
           {["gross_motor", "fine_motor"].map((cat) => (
             <button
               key={cat}
-              onClick={() =>
-                router.push(`/children/${childId}/motor/${cat}`)
-              }
+              onClick={() => {
+                router.push(`/children/${childId}/motor/${cat}`);
+                setAssessMode(false);
+              }}
               className={`flex-1 rounded-[var(--radius-input)] px-4 py-3 text-sm font-semibold transition-all duration-200 cursor-pointer min-h-[44px] ${
                 category === cat
                   ? "bg-terracotta text-white"
@@ -132,7 +166,6 @@ export default function MotorCategoryPage() {
           ))}
         </div>
 
-        {/* Checklist */}
         {loading ? (
           <p className="text-olive-muted text-center">Loading...</p>
         ) : checklist.length === 0 ? (
@@ -141,27 +174,133 @@ export default function MotorCategoryPage() {
               Complete the onboarding quiz to populate milestones.
             </p>
           </div>
+        ) : assessMode ? (
+          /* Questionnaire mode */
+          <div>
+            {/* Progress */}
+            <div className="mb-6">
+              <div className="flex justify-between text-xs text-olive-light mb-2">
+                <span>
+                  {currentIndex + 1} of {assessList.length}
+                </span>
+                <span>
+                  {Math.round(((currentIndex + 1) / assessList.length) * 100)}%
+                </span>
+              </div>
+              <div className="h-2 rounded-full bg-sand-light overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-terracotta transition-all duration-300"
+                  style={{
+                    width: `${((currentIndex + 1) / assessList.length) * 100}%`,
+                  }}
+                />
+              </div>
+            </div>
+
+            {/* Question card */}
+            <div className="rounded-[var(--radius-card)] border border-sand-light bg-warm-white p-6 shadow-[var(--shadow-card)] mb-6">
+              <p className="text-lg font-semibold text-olive-dark leading-relaxed">
+                Is your child: {assessList[currentIndex]}?
+              </p>
+              {statuses[assessList[currentIndex]] && (
+                <p className="text-sm text-olive-muted mt-2">
+                  Currently:{" "}
+                  {statusLabels[statuses[assessList[currentIndex]]]}
+                </p>
+              )}
+            </div>
+
+            {/* Answer buttons */}
+            <div className="flex flex-col gap-3">
+              <button
+                onClick={() =>
+                  handleAnswer(assessList[currentIndex], "consistently")
+                }
+                disabled={saving}
+                className="w-full rounded-[var(--radius-button)] bg-terracotta px-6 py-4 font-semibold text-white shadow-[var(--shadow-button)] transition-all duration-200 hover:bg-terracotta-dark disabled:opacity-50 cursor-pointer min-h-[52px]"
+              >
+                Yes, consistently!
+              </button>
+              <button
+                onClick={() =>
+                  handleAnswer(assessList[currentIndex], "sometimes")
+                }
+                disabled={saving}
+                className="w-full rounded-[var(--radius-button)] border-2 border-sand-light bg-warm-white px-6 py-4 font-semibold text-olive-dark transition-all duration-200 hover:bg-sand-light disabled:opacity-50 cursor-pointer min-h-[52px]"
+              >
+                Sometimes
+              </button>
+              <button
+                onClick={() =>
+                  handleAnswer(assessList[currentIndex], "not_yet")
+                }
+                disabled={saving}
+                className="w-full rounded-[var(--radius-button)] border-2 border-sand-light bg-warm-white px-6 py-4 font-semibold text-olive-muted transition-all duration-200 hover:bg-sand-light disabled:opacity-50 cursor-pointer min-h-[52px]"
+              >
+                Not yet
+              </button>
+            </div>
+
+            <button
+              onClick={() => {
+                setAssessMode(false);
+                setCurrentIndex(0);
+              }}
+              className="w-full mt-4 text-sm text-olive-muted hover:text-olive-dark cursor-pointer text-center py-2"
+            >
+              Exit assessment
+            </button>
+          </div>
         ) : (
-          <div className="flex flex-col gap-2">
-            {checklist.map((name) => {
-              const status = statuses[name] || "not_yet";
-              return (
+          /* Summary view */
+          <div>
+            {/* Summary stats */}
+            <div className="rounded-[var(--radius-card)] border border-sand-light bg-warm-white p-4 mb-4 shadow-[var(--shadow-card)]">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="font-semibold text-olive-dark">
+                    {achievedCount} achieved
+                    {sometimesCount > 0 &&
+                      ` · ${sometimesCount} sometimes`}
+                  </p>
+                  <p className="text-xs text-olive-muted mt-0.5">
+                    {checklist.length} milestones total
+                  </p>
+                </div>
                 <button
-                  key={name}
-                  onClick={() => toggleStatus(name)}
-                  className="flex items-center justify-between rounded-[var(--radius-card)] border border-sand-light bg-warm-white p-4 transition-all duration-200 hover:shadow-[var(--shadow-card)] cursor-pointer text-left min-h-[52px]"
+                  onClick={startAssessment}
+                  className="rounded-[var(--radius-button)] bg-terracotta px-4 py-2.5 text-sm font-semibold text-white shadow-[var(--shadow-button)] transition-all duration-200 hover:bg-terracotta-dark cursor-pointer"
                 >
-                  <span className="text-sm text-olive-dark font-medium flex-1 pr-3">
-                    {name}
-                  </span>
-                  <span
-                    className={`text-xs font-semibold rounded-full px-3 py-1 whitespace-nowrap ${statusColors[status]}`}
-                  >
-                    {statusLabels[status]}
-                  </span>
+                  Assess
                 </button>
-              );
-            })}
+              </div>
+            </div>
+
+            {/* Milestone list */}
+            <p className="text-olive-muted text-xs mb-2">
+              Tap a milestone to change its status.
+            </p>
+            <div className="flex flex-col gap-2">
+              {checklist.map((name) => {
+                const status = statuses[name] || "not_yet";
+                return (
+                  <button
+                    key={name}
+                    onClick={() => toggleStatus(name)}
+                    className="flex items-center justify-between rounded-[var(--radius-card)] border border-sand-light bg-warm-white p-4 min-h-[52px] transition-all duration-200 hover:shadow-[var(--shadow-card)] cursor-pointer text-left"
+                  >
+                    <span className="text-sm text-olive-dark font-medium flex-1 pr-3">
+                      {name}
+                    </span>
+                    <span
+                      className={`text-xs font-semibold rounded-full px-3 py-1 whitespace-nowrap ${statusColors[status]}`}
+                    >
+                      {statusLabels[status]}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
           </div>
         )}
       </div>

--- a/app/(app)/children/[childId]/predictions/page.tsx
+++ b/app/(app)/children/[childId]/predictions/page.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useParams, useRouter } from "next/navigation";
+
+import { BottomNav } from "@/components/bottom-nav";
+
+interface Prediction {
+  category: string;
+  title: string;
+  description: string;
+  timeframe: string;
+  signs: string[];
+}
+
+const categoryLabels: Record<string, string> = {
+  language: "Language",
+  gross_motor: "Gross Motor",
+  fine_motor: "Fine Motor",
+};
+
+const categoryColors: Record<string, { bg: string; text: string; border: string }> = {
+  language: { bg: "bg-lang-bg", text: "text-lang", border: "border-lang-bg" },
+  gross_motor: { bg: "bg-gross-bg", text: "text-gross", border: "border-gross-bg" },
+  fine_motor: { bg: "bg-fine-bg", text: "text-fine", border: "border-fine-bg" },
+};
+
+export default function PredictionsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const childId = params.childId as string;
+
+  // TODO: Re-enable AI predictions when ready
+  const _comingSoon = true;
+
+  const [predictions, setPredictions] = useState<Prediction[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const _categories = ["language", "gross_motor", "fine_motor"];
+
+  // Preserved for future use — fetch predictions from AI
+  function _loadPredictions() {
+    setLoading(true);
+    setError("");
+    fetch(`/api/children/${childId}/predictions`)
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed to load");
+        return res.json();
+      })
+      .then((data) => {
+        setPredictions(data.data ?? []);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError("Couldn't generate predictions right now. Try again later.");
+        setLoading(false);
+      });
+  }
+
+  // Suppress unused variable warnings
+  void predictions;
+  void loading;
+  void error;
+  void setPredictions;
+
+  return (
+    <main className="min-h-dvh px-6 pt-8 pb-24">
+      <div className="mx-auto max-w-sm">
+        {/* Header */}
+        <div className="mb-6">
+          <button
+            onClick={() => router.push("/dashboard")}
+            className="text-sm text-olive-muted hover:text-olive-dark cursor-pointer mb-1"
+          >
+            &#8249; Dashboard
+          </button>
+          <h1 className="font-[family-name:var(--font-heading)] text-3xl text-olive-dark">
+            What&apos;s Next
+          </h1>
+        </div>
+
+        {/* Coming Soon */}
+        <div className="text-center py-16">
+          <div className="w-16 h-16 rounded-full bg-terracotta-light flex items-center justify-center mx-auto mb-4">
+            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#c2775e" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+            </svg>
+          </div>
+          <h2 className="font-[family-name:var(--font-heading)] text-2xl text-olive-dark mb-2">
+            Coming Soon
+          </h2>
+          <p className="text-olive-muted text-sm max-w-[240px] mx-auto">
+            Personalized predictions for your child&apos;s next milestones are on the way.
+          </p>
+        </div>
+      </div>
+
+      <BottomNav childId={childId} />
+    </main>
+  );
+}

--- a/app/(app)/children/[childId]/quiz/page.tsx
+++ b/app/(app)/children/[childId]/quiz/page.tsx
@@ -22,15 +22,29 @@ export default function QuizPage() {
   >([]);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
+  const [bracketMax, setBracketMax] = useState(0);
+  const [advancing, setAdvancing] = useState(false);
+  const [totalAnswered, setTotalAnswered] = useState(0);
 
   useEffect(() => {
     fetch(`/api/children/${childId}/quiz`)
       .then((res) => res.json())
       .then((data) => {
         setQuestions(data.data.questions);
+        setBracketMax(data.data.bracketMax);
         setLoading(false);
       });
   }, [childId]);
+
+  async function submitAnswers(
+    answersToSubmit: { questionId: string; answer: string }[]
+  ) {
+    await fetch(`/api/children/${childId}/quiz`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ answers: answersToSubmit }),
+    });
+  }
 
   async function handleAnswer(answer: "yes" | "no") {
     const question = questions[currentIndex];
@@ -39,15 +53,37 @@ export default function QuizPage() {
 
     if (currentIndex < questions.length - 1) {
       setCurrentIndex(currentIndex + 1);
-    } else {
-      setSubmitting(true);
-      await fetch(`/api/children/${childId}/quiz`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ answers: newAnswers }),
-      });
-      router.push("/dashboard");
+      return;
     }
+
+    // Finished current batch — submit these answers
+    setSubmitting(true);
+    await submitAnswers(newAnswers);
+
+    const allYes = newAnswers.every((a) => a.answer === "yes");
+
+    if (allYes) {
+      // Try loading the next bracket
+      setAdvancing(true);
+      const res = await fetch(
+        `/api/children/${childId}/quiz?after=${bracketMax}`
+      );
+      const data = await res.json();
+      const nextQuestions: QuizQuestion[] = data.data.questions;
+
+      if (nextQuestions.length > 0) {
+        setTotalAnswered((prev) => prev + newAnswers.length);
+        setQuestions(nextQuestions);
+        setBracketMax(data.data.bracketMax);
+        setCurrentIndex(0);
+        setAnswers([]);
+        setSubmitting(false);
+        setAdvancing(false);
+        return;
+      }
+    }
+
+    router.push("/dashboard");
   }
 
   if (loading) {
@@ -76,14 +112,22 @@ export default function QuizPage() {
 
   if (submitting) {
     return (
-      <main className="flex min-h-dvh items-center justify-center">
-        <p className="text-olive-muted">Saving your answers...</p>
+      <main className="flex min-h-dvh items-center justify-center px-6">
+        <div className="text-center">
+          <p className="text-olive-muted">
+            {advancing
+              ? "Great job! Loading more questions..."
+              : "Saving your answers..."}
+          </p>
+        </div>
       </main>
     );
   }
 
   const question = questions[currentIndex];
-  const progress = ((currentIndex + 1) / questions.length) * 100;
+  const displayIndex = totalAnswered + currentIndex + 1;
+  const displayTotal = totalAnswered + questions.length;
+  const progress = (displayIndex / displayTotal) * 100;
 
   const categoryLabels: Record<string, string> = {
     language: "Language",
@@ -104,7 +148,8 @@ export default function QuizPage() {
         <div className="mb-8">
           <div className="flex justify-between text-xs text-olive-light mb-2">
             <span>
-              {currentIndex + 1} of {questions.length}
+              {displayIndex} of {displayTotal}
+              {totalAnswered > 0 ? "+" : ""}
             </span>
             <span>{Math.round(progress)}%</span>
           </div>

--- a/app/(app)/children/new/page.tsx
+++ b/app/(app)/children/new/page.tsx
@@ -4,12 +4,39 @@ import { useState } from "react";
 
 import { useRouter } from "next/navigation";
 
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+function getDaysInMonth(month: number, year: number): number {
+  if (!month || !year) return 31;
+  return new Date(year, month, 0).getDate();
+}
+
+function buildYearOptions(): number[] {
+  const currentYear = new Date().getFullYear();
+  const years: number[] = [];
+  for (let y = currentYear; y >= currentYear - 5; y--) {
+    years.push(y);
+  }
+  return years;
+}
+
 export default function NewChildPage() {
   const router = useRouter();
   const [name, setName] = useState("");
-  const [dateOfBirth, setDateOfBirth] = useState("");
+  const [birthMonth, setBirthMonth] = useState("");
+  const [birthDay, setBirthDay] = useState("");
+  const [birthYear, setBirthYear] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+
+  const daysInMonth = getDaysInMonth(Number(birthMonth), Number(birthYear));
+  const dateOfBirth =
+    birthMonth && birthDay && birthYear
+      ? `${birthYear}-${birthMonth.padStart(2, "0")}-${birthDay.padStart(2, "0")}`
+      : "";
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -62,22 +89,56 @@ export default function NewChildPage() {
             />
           </div>
 
-          <div>
-            <label
-              htmlFor="dob"
-              className="block text-sm font-medium text-olive-muted mb-1"
-            >
+          <fieldset>
+            <legend className="block text-sm font-medium text-olive-muted mb-1">
               Date of birth
-            </label>
-            <input
-              id="dob"
-              type="date"
-              value={dateOfBirth}
-              onChange={(e) => setDateOfBirth(e.target.value)}
-              required
-              className="w-full rounded-[var(--radius-input)] border border-sand-light bg-warm-white px-4 py-3 text-olive-dark focus:border-terracotta focus:outline-none focus:ring-2 focus:ring-terracotta/20"
-            />
-          </div>
+            </legend>
+            <div className="grid grid-cols-[1fr_0.6fr_0.8fr] gap-2">
+              <select
+                value={birthMonth}
+                onChange={(e) => {
+                  setBirthMonth(e.target.value);
+                  if (Number(birthDay) > getDaysInMonth(Number(e.target.value), Number(birthYear))) {
+                    setBirthDay("");
+                  }
+                }}
+                required
+                className="w-full rounded-[var(--radius-input)] border border-sand-light bg-warm-white px-3 py-3 text-olive-dark focus:border-terracotta focus:outline-none focus:ring-2 focus:ring-terracotta/20 appearance-none cursor-pointer"
+              >
+                <option value="" disabled>Month</option>
+                {MONTHS.map((m, i) => (
+                  <option key={m} value={String(i + 1)}>{m}</option>
+                ))}
+              </select>
+              <select
+                value={birthDay}
+                onChange={(e) => setBirthDay(e.target.value)}
+                required
+                className="w-full rounded-[var(--radius-input)] border border-sand-light bg-warm-white px-3 py-3 text-olive-dark focus:border-terracotta focus:outline-none focus:ring-2 focus:ring-terracotta/20 appearance-none cursor-pointer"
+              >
+                <option value="" disabled>Day</option>
+                {Array.from({ length: daysInMonth }, (_, i) => (
+                  <option key={i + 1} value={String(i + 1)}>{i + 1}</option>
+                ))}
+              </select>
+              <select
+                value={birthYear}
+                onChange={(e) => {
+                  setBirthYear(e.target.value);
+                  if (Number(birthDay) > getDaysInMonth(Number(birthMonth), Number(e.target.value))) {
+                    setBirthDay("");
+                  }
+                }}
+                required
+                className="w-full rounded-[var(--radius-input)] border border-sand-light bg-warm-white px-3 py-3 text-olive-dark focus:border-terracotta focus:outline-none focus:ring-2 focus:ring-terracotta/20 appearance-none cursor-pointer"
+              >
+                <option value="" disabled>Year</option>
+                {buildYearOptions().map((y) => (
+                  <option key={y} value={String(y)}>{y}</option>
+                ))}
+              </select>
+            </div>
+          </fieldset>
 
           {error && (
             <p className="text-sm text-red-600 bg-red-50 rounded-[var(--radius-input)] px-3 py-2">

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -21,17 +21,20 @@ const categoryMeta: Record<
   fine_motor: { label: "Fine Motor", dotClass: "bg-fine" },
 };
 
-export default async function DashboardPage() {
+export default async function DashboardPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ child?: string }>;
+}) {
   const session = await auth();
+  const { child: selectedChildId } = await searchParams;
 
   const childList = await db
     .select()
     .from(children)
     .where(eq(children.userId, session!.user!.id!));
 
-  const child = childList[0];
-
-  if (!child) {
+  if (childList.length === 0) {
     return (
       <main className="min-h-dvh px-6 py-8">
         <div className="mx-auto max-w-sm">
@@ -59,6 +62,9 @@ export default async function DashboardPage() {
     );
   }
 
+  const child =
+    childList.find((c) => c.id === selectedChildId) || childList[0];
+
   const [categories, wordStats, recentActivity] = await Promise.all([
     getMilestonesByCategory(child.id),
     getWordStats(child.id),
@@ -77,11 +83,39 @@ export default async function DashboardPage() {
     <main className="min-h-dvh px-6 pt-8 pb-24">
       <div className="mx-auto max-w-sm">
         {/* Header */}
-        <div className="text-center mb-6">
+        <div className="text-center mb-4">
           <p className="font-[family-name:var(--font-heading)] text-sm text-terracotta tracking-wide">
             totter
           </p>
-          <h1 className="font-[family-name:var(--font-heading)] text-4xl text-olive-dark mt-1">
+        </div>
+
+        {/* Child switcher */}
+        <div className="flex items-center justify-center gap-2 mb-6 flex-wrap">
+          {childList.map((c) => (
+            <Link
+              key={c.id}
+              href={`/dashboard?child=${c.id}`}
+              className={`rounded-full px-4 py-1.5 text-sm font-semibold transition-all duration-200 cursor-pointer ${
+                c.id === child.id
+                  ? "bg-terracotta text-white shadow-[var(--shadow-button)]"
+                  : "bg-sand-light text-olive-muted hover:bg-terracotta-light hover:text-terracotta"
+              }`}
+            >
+              {c.name}
+            </Link>
+          ))}
+          <Link
+            href="/children/new"
+            className="w-8 h-8 rounded-full bg-sand-light text-olive-muted flex items-center justify-center text-lg font-bold transition-all duration-200 hover:bg-terracotta-light hover:text-terracotta cursor-pointer"
+            title="Add child"
+          >
+            +
+          </Link>
+        </div>
+
+        {/* Child info */}
+        <div className="text-center mb-6">
+          <h1 className="font-[family-name:var(--font-heading)] text-4xl text-olive-dark">
             {child.name}
           </h1>
           <p className="text-olive-muted text-sm mt-1">
@@ -203,6 +237,33 @@ export default async function DashboardPage() {
             className="flex-1 rounded-[var(--radius-button)] border-2 border-sand-light bg-warm-white px-4 py-4 text-center font-semibold text-terracotta transition-all duration-200 hover:bg-terracotta-light cursor-pointer min-h-[52px]"
           >
             Get Tips
+          </Link>
+        </div>
+
+        {/* Timeline & Predictions */}
+        <div className="flex gap-3 mt-3">
+          <Link
+            href={`/children/${child.id}/timeline`}
+            className="flex-1 rounded-[var(--radius-card)] border border-sand-light bg-warm-white p-4 shadow-[var(--shadow-card)] transition-all duration-200 hover:shadow-[var(--shadow-card-hover)] hover:translate-y-[-2px] cursor-pointer flex items-center gap-3"
+          >
+            <div className="w-9 h-9 rounded-[12px] bg-sand-light flex items-center justify-center shrink-0">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#8b7355" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="10" />
+                <polyline points="12 6 12 12 16 14" />
+              </svg>
+            </div>
+            <span className="font-semibold text-olive-dark text-sm">Timeline</span>
+          </Link>
+          <Link
+            href={`/children/${child.id}/predictions`}
+            className="flex-1 rounded-[var(--radius-card)] border border-sand-light bg-warm-white p-4 shadow-[var(--shadow-card)] transition-all duration-200 hover:shadow-[var(--shadow-card-hover)] hover:translate-y-[-2px] cursor-pointer flex items-center gap-3"
+          >
+            <div className="w-9 h-9 rounded-[12px] bg-terracotta-light flex items-center justify-center shrink-0">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#c2775e" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+              </svg>
+            </div>
+            <span className="font-semibold text-olive-dark text-sm">What&apos;s Next</span>
           </Link>
         </div>
 

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 
 import { signOut } from "next-auth/react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 interface Child {
@@ -13,14 +14,16 @@ interface Child {
 
 export default function SettingsPage() {
   const router = useRouter();
-  const [child, setChild] = useState<Child | null>(null);
+  const [children, setChildren] = useState<Child[]>([]);
+  const [confirmingDelete, setConfirmingDelete] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
     fetch("/api/children")
       .then((res) => res.json())
       .then((data) => {
-        if (data.data && data.data.length > 0) {
-          setChild(data.data[0]);
+        if (data.data) {
+          setChildren(data.data);
         }
       });
   }, []);
@@ -40,35 +43,88 @@ export default function SettingsPage() {
           </h1>
         </div>
 
-        {/* Child info */}
-        {child && (
-          <div className="rounded-[var(--radius-card)] border border-sand-light bg-warm-white p-5 shadow-[var(--shadow-card)] mb-4">
-            <h2 className="font-semibold text-olive-dark mb-2">
-              {child.name}
-            </h2>
-            <p className="text-sm text-olive-muted">
-              Born{" "}
-              {new Date(child.dateOfBirth + "T00:00:00").toLocaleDateString("en-US", {
-                month: "long",
-                day: "numeric",
-                year: "numeric",
-              })}
-            </p>
-          </div>
-        )}
+        {/* Children list */}
+        <h2 className="text-xs font-bold text-olive-light uppercase tracking-wider mb-3">
+          Children
+        </h2>
+        <div className="flex flex-col gap-3 mb-4">
+          {children.map((child) => (
+            <div
+              key={child.id}
+              className="rounded-[var(--radius-card)] border border-sand-light bg-warm-white p-5 shadow-[var(--shadow-card)]"
+            >
+              <div className="flex items-center justify-between mb-2">
+                <h3 className="font-semibold text-olive-dark">{child.name}</h3>
+              </div>
+              <p className="text-sm text-olive-muted mb-3">
+                Born{" "}
+                {new Date(child.dateOfBirth + "T00:00:00").toLocaleDateString(
+                  "en-US",
+                  { month: "long", day: "numeric", year: "numeric" }
+                )}
+              </p>
+              <div className="flex items-center gap-4">
+                <button
+                  onClick={() => router.push(`/children/${child.id}/quiz`)}
+                  className="text-sm font-semibold text-terracotta hover:text-terracotta-dark cursor-pointer"
+                >
+                  Retake quiz
+                </button>
+                <button
+                  onClick={() => setConfirmingDelete(child.id)}
+                  className="text-sm font-semibold text-red-400 hover:text-red-600 cursor-pointer"
+                >
+                  Remove
+                </button>
+              </div>
+              {confirmingDelete === child.id && (
+                <div className="mt-3 pt-3 border-t border-sand-light">
+                  <p className="text-sm text-olive-muted mb-3">
+                    Remove {child.name} and all their milestones? This can&apos;t
+                    be undone.
+                  </p>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={async () => {
+                        setDeleting(true);
+                        const res = await fetch("/api/children", {
+                          method: "DELETE",
+                          headers: { "Content-Type": "application/json" },
+                          body: JSON.stringify({ childId: child.id }),
+                        });
+                        if (res.ok) {
+                          setChildren((prev) =>
+                            prev.filter((c) => c.id !== child.id)
+                          );
+                        }
+                        setDeleting(false);
+                        setConfirmingDelete(null);
+                      }}
+                      disabled={deleting}
+                      className="rounded-[var(--radius-button)] bg-red-500 px-4 py-2 text-sm font-semibold text-white hover:bg-red-600 disabled:opacity-50 cursor-pointer"
+                    >
+                      {deleting ? "Removing..." : "Yes, remove"}
+                    </button>
+                    <button
+                      onClick={() => setConfirmingDelete(null)}
+                      className="rounded-[var(--radius-button)] bg-sand-light px-4 py-2 text-sm font-semibold text-olive-muted hover:bg-sand cursor-pointer"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
 
-        {/* Retake quiz */}
-        {child && (
-          <button
-            onClick={() => router.push(`/children/${child.id}/quiz`)}
-            className="w-full rounded-[var(--radius-card)] border border-sand-light bg-warm-white p-5 shadow-[var(--shadow-card)] mb-4 text-left cursor-pointer hover:shadow-[var(--shadow-card-hover)] transition-all duration-200"
-          >
-            <p className="font-semibold text-olive-dark">Retake quiz</p>
-            <p className="text-sm text-olive-muted mt-1">
-              Re-assess milestones with a fresh set of questions.
-            </p>
-          </button>
-        )}
+        {/* Add child */}
+        <Link
+          href="/children/new"
+          className="flex items-center justify-center gap-2 w-full rounded-[var(--radius-card)] border-2 border-dashed border-sand-light p-4 text-sm font-semibold text-olive-muted transition-all duration-200 hover:border-terracotta hover:text-terracotta cursor-pointer mb-6"
+        >
+          + Add another child
+        </Link>
 
         {/* Logout */}
         <button

--- a/app/api/children/[childId]/predictions/route.ts
+++ b/app/api/children/[childId]/predictions/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { children, milestones, wordLogs } from "@/lib/db/schema";
+import { getAgeInMonths } from "@/lib/utils";
+import { generatePredictions } from "@/lib/ai/client";
+import type { PredictionInput } from "@/lib/ai/types";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ childId: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { childId } = await params;
+
+  const child = await db
+    .select()
+    .from(children)
+    .where(eq(children.id, childId))
+    .get();
+
+  if (!child || child.userId !== session.user.id) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  try {
+    const ageMonths = getAgeInMonths(child.dateOfBirth);
+
+    const childMilestones = await db
+      .select({
+        category: milestones.category,
+        name: milestones.name,
+        status: milestones.status,
+      })
+      .from(milestones)
+      .where(eq(milestones.childId, childId));
+
+    const wordEntries = await db
+      .select()
+      .from(wordLogs)
+      .where(eq(wordLogs.childId, childId));
+
+    const wordCount = wordEntries.filter((w) => !w.isPhrase).length;
+    const phraseCount = wordEntries.filter((w) => w.isPhrase).length;
+
+    const input: PredictionInput = {
+      ageMonths,
+      childName: child.name,
+      milestones: childMilestones,
+      wordCount,
+      phraseCount,
+    };
+
+    const output = await generatePredictions(input);
+
+    return NextResponse.json({ data: output.predictions });
+  } catch (error) {
+    console.error("Prediction error:", error);
+    return NextResponse.json(
+      { error: "Failed to generate predictions" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/children/[childId]/quiz/route.ts
+++ b/app/api/children/[childId]/quiz/route.ts
@@ -1,11 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { children } from "@/lib/db/schema";
-import { getQuestionsForAge, processQuizResults } from "@/lib/quiz/engine";
+import { children, milestones } from "@/lib/db/schema";
+import {
+  getQuestionsForAge,
+  getQuestionsForNextBracket,
+  getBracketMaxForAge,
+  processQuizResults,
+} from "@/lib/quiz/engine";
 import { getAgeInMonths } from "@/lib/utils";
 
 const quizAnswerSchema = z.object({
@@ -39,9 +44,34 @@ export async function GET(
   }
 
   const ageMonths = getAgeInMonths(child.dateOfBirth);
-  const questions = getQuestionsForAge(ageMonths);
+  const afterParam = _request.nextUrl.searchParams.get("after");
 
-  return NextResponse.json({ data: { questions, ageMonths } });
+  let questions;
+  let bracketMax: number;
+
+  if (afterParam) {
+    questions = getQuestionsForNextBracket(Number(afterParam));
+    bracketMax = questions.length > 0 ? questions[0].maxMonths : Number(afterParam);
+  } else {
+    questions = getQuestionsForAge(ageMonths);
+    bracketMax = getBracketMaxForAge(ageMonths);
+  }
+
+  // Filter out questions whose milestone is already "consistently" achieved
+  const consistentMilestones = await db
+    .select({ name: milestones.name })
+    .from(milestones)
+    .where(
+      and(
+        eq(milestones.childId, childId),
+        eq(milestones.status, "consistently")
+      )
+    );
+
+  const consistentNames = new Set(consistentMilestones.map((m) => m.name));
+  questions = questions.filter((q) => !consistentNames.has(q.milestoneIfYes));
+
+  return NextResponse.json({ data: { questions, ageMonths, bracketMax } });
 }
 
 export async function POST(

--- a/app/api/children/[childId]/words/route.ts
+++ b/app/api/children/[childId]/words/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { eq, desc } from "drizzle-orm";
+import { and, eq, desc } from "drizzle-orm";
 
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
@@ -8,12 +8,13 @@ import { children, wordLogs } from "@/lib/db/schema";
 
 const addWordSchema = z.object({
   word: z.string().min(1, "Word is required"),
+  type: z.enum(["word", "gesture"]).default("word"),
   isPhrase: z.boolean().default(false),
   observedDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD"),
 });
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ childId: string }> }
 ) {
   const session = await auth();
@@ -33,10 +34,16 @@ export async function GET(
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
+  const typeFilter = request.nextUrl.searchParams.get("type");
+  const conditions = [eq(wordLogs.childId, childId)];
+  if (typeFilter === "word" || typeFilter === "gesture") {
+    conditions.push(eq(wordLogs.type, typeFilter));
+  }
+
   const words = await db
     .select()
     .from(wordLogs)
-    .where(eq(wordLogs.childId, childId))
+    .where(and(...conditions))
     .orderBy(desc(wordLogs.observedDate));
 
   return NextResponse.json({ data: words });
@@ -65,14 +72,62 @@ export async function POST(
 
   try {
     const body = await request.json();
-    const { word, isPhrase, observedDate } = addWordSchema.parse(body);
+    const { word, type, isPhrase, observedDate } = addWordSchema.parse(body);
 
     const result = await db
       .insert(wordLogs)
-      .values({ childId, word, isPhrase, observedDate })
+      .values({ childId, word, type, isPhrase, observedDate })
       .returning();
 
     return NextResponse.json({ data: result[0] }, { status: 201 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: error.errors[0].message },
+        { status: 400 }
+      );
+    }
+    return NextResponse.json(
+      { error: "Something went wrong" },
+      { status: 500 }
+    );
+  }
+}
+
+const deleteWordSchema = z.object({
+  wordId: z.string().min(1),
+});
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ childId: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { childId } = await params;
+
+  const child = await db
+    .select()
+    .from(children)
+    .where(eq(children.id, childId))
+    .get();
+
+  if (!child || child.userId !== session.user.id) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  try {
+    const body = await request.json();
+    const { wordId } = deleteWordSchema.parse(body);
+
+    await db
+      .delete(wordLogs)
+      .where(and(eq(wordLogs.id, wordId), eq(wordLogs.childId, childId)));
+
+    return NextResponse.json({ data: { success: true } });
   } catch (error) {
     if (error instanceof z.ZodError) {
       return NextResponse.json(

--- a/app/api/children/route.ts
+++ b/app/api/children/route.ts
@@ -1,10 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { children } from "@/lib/db/schema";
+import {
+  children,
+  milestones,
+  wordLogs,
+  quizResponses,
+  recommendations,
+} from "@/lib/db/schema";
 
 const createChildSchema = z.object({
   name: z.string().min(1, "Name is required"),
@@ -53,4 +59,49 @@ export async function GET() {
     .where(eq(children.userId, session.user.id));
 
   return NextResponse.json({ data: result });
+}
+
+const deleteChildSchema = z.object({
+  childId: z.string().min(1),
+});
+
+export async function DELETE(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const { childId } = deleteChildSchema.parse(body);
+
+    const child = await db
+      .select()
+      .from(children)
+      .where(and(eq(children.id, childId), eq(children.userId, session.user.id)))
+      .get();
+
+    if (!child) {
+      return NextResponse.json({ error: "Child not found" }, { status: 404 });
+    }
+
+    await db.delete(recommendations).where(eq(recommendations.childId, childId));
+    await db.delete(quizResponses).where(eq(quizResponses.childId, childId));
+    await db.delete(wordLogs).where(eq(wordLogs.childId, childId));
+    await db.delete(milestones).where(eq(milestones.childId, childId));
+    await db.delete(children).where(eq(children.id, childId));
+
+    return NextResponse.json({ data: { success: true } });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: error.errors[0].message },
+        { status: 400 }
+      );
+    }
+    return NextResponse.json(
+      { error: "Something went wrong" },
+      { status: 500 }
+    );
+  }
 }

--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -25,7 +25,7 @@ export function BottomNav({ childId }: { childId: string }) {
     },
     {
       href: `/children/${childId}/language`,
-      label: "Words",
+      label: "Comms",
       icon: (
         <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
@@ -43,12 +43,12 @@ export function BottomNav({ childId }: { childId: string }) {
       ),
     },
     {
-      href: `/children/${childId}/timeline`,
-      label: "Timeline",
+      href: "/settings",
+      label: "Settings",
       icon: (
         <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <circle cx="12" cy="12" r="10" />
-          <polyline points="12 6 12 12 16 14" />
+          <circle cx="12" cy="12" r="3" />
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
         </svg>
       ),
     },

--- a/lib/ai/client.ts
+++ b/lib/ai/client.ts
@@ -1,7 +1,12 @@
 import Anthropic from "@anthropic-ai/sdk";
 
-import { SYSTEM_PROMPT } from "./prompts";
-import type { RecommendationInput, RecommendationOutput } from "./types";
+import { SYSTEM_PROMPT, PREDICTIONS_SYSTEM_PROMPT } from "./prompts";
+import type {
+  RecommendationInput,
+  RecommendationOutput,
+  PredictionInput,
+  PredictionOutput,
+} from "./types";
 
 const MODEL = "claude-haiku-4-5-20251001";
 
@@ -19,10 +24,15 @@ export async function generateRecommendation(
     messages: [{ role: "user", content: userMessage }],
   });
 
-  const text =
+  const rawText =
     response.content[0].type === "text" ? response.content[0].text : "";
 
-  const parsed = JSON.parse(text) as RecommendationOutput;
+  const jsonMatch = rawText.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    throw new Error("No JSON found in AI response");
+  }
+
+  const parsed = JSON.parse(jsonMatch[0]) as RecommendationOutput;
   return parsed;
 }
 
@@ -63,4 +73,63 @@ function formatCategory(category: string): string {
     general: "General Development",
   };
   return labels[category] || category;
+}
+
+export async function generatePredictions(
+  input: PredictionInput
+): Promise<PredictionOutput> {
+  const client = new Anthropic();
+
+  const userMessage = buildPredictionMessage(input);
+
+  const response = await client.messages.create({
+    model: MODEL,
+    max_tokens: 1500,
+    system: PREDICTIONS_SYSTEM_PROMPT,
+    messages: [{ role: "user", content: userMessage }],
+  });
+
+  const raw =
+    response.content[0].type === "text" ? response.content[0].text : "";
+
+  // Extract JSON object from response, handling code fences and trailing text
+  const jsonMatch = raw.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    throw new Error("No JSON found in AI response");
+  }
+
+  const parsed = JSON.parse(jsonMatch[0]) as PredictionOutput;
+  return parsed;
+}
+
+function buildPredictionMessage(input: PredictionInput): string {
+  const parts: string[] = [
+    `Child: ${input.childName}, ${input.ageMonths} months old`,
+    "",
+    "Current milestones by category:",
+  ];
+
+  const byCategory: Record<string, typeof input.milestones> = {};
+  for (const m of input.milestones) {
+    if (!byCategory[m.category]) byCategory[m.category] = [];
+    byCategory[m.category].push(m);
+  }
+
+  for (const [cat, items] of Object.entries(byCategory)) {
+    parts.push(`\n${formatCategory(cat)}:`);
+    for (const m of items) {
+      parts.push(`  - ${m.name}: ${m.status}`);
+    }
+  }
+
+  if (input.milestones.length === 0) {
+    parts.push("  (no milestones logged yet)");
+  }
+
+  parts.push("");
+  parts.push(`Language stats: ${input.wordCount} words, ${input.phraseCount} phrases`);
+  parts.push("");
+  parts.push("Based on this child's current development, predict what milestones are likely coming next across all three categories (language, gross motor, fine motor).");
+
+  return parts.join("\n");
 }

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -57,3 +57,61 @@ OUTPUT FORMAT: Respond with valid JSON matching this structure:
 }
 
 Provide 2-3 recommendations per request. Each should have 2-4 specific activities.`;
+
+export const PREDICTIONS_SYSTEM_PROMPT = `You are a warm, knowledgeable developmental milestone advisor for parents of infants and toddlers (0-36 months). You are NOT a doctor.
+
+Your role is to predict what developmental milestones a child is likely to reach next, based on their current progress and age. Use CDC 2022 revised milestone baselines.
+
+Developmental baselines (CDC 2022 revised):
+
+LANGUAGE:
+- 2mo: Coos, gurgling
+- 4mo: Babbles, responds to sounds
+- 6mo: Responds to name, strings vowels together
+- 9mo: Understands "no", copies sounds
+- 12mo: 1-3 words with meaning, uses gestures
+- 15mo: 3+ words, follows simple directions
+- 18mo: 10+ words, points to show things
+- 24mo: 50+ words, 2-word phrases
+- 36mo: Conversations, 3-word sentences
+
+GROSS MOTOR:
+- 2mo: Holds head up on tummy
+- 4mo: Pushes up on arms
+- 6mo: Rolls both ways, sits with support
+- 9mo: Sits without support, may crawl
+- 12mo: Pulls to stand, may take steps
+- 15mo: Walking independently
+- 18mo: Running, climbing
+- 24mo: Kicks ball, jumps
+
+FINE MOTOR:
+- 4mo: Reaches for toys, brings hands to mouth
+- 6mo: Passes toys between hands
+- 9mo: Pincer grasp
+- 12mo: Puts things in containers, stacks 2 blocks
+- 18mo: Scribbles, self-feeds with spoon
+- 24mo: Stacks 4+ blocks, turns pages
+
+RULES:
+1. Predict milestones the child hasn't achieved yet but is developmentally approaching
+2. Give a realistic timeframe (e.g., "in the next 1-2 months", "over the coming weeks")
+3. List early signs parents can watch for
+4. Be encouraging and excited about what's coming
+5. Use warm language — you're giving parents something to look forward to
+6. Provide predictions across all three categories: language, gross_motor, fine_motor
+
+OUTPUT FORMAT: Respond with valid JSON:
+{
+  "predictions": [
+    {
+      "category": "language" | "gross_motor" | "fine_motor",
+      "title": "Short exciting title about the milestone",
+      "description": "2-3 sentences about what this milestone looks like and why it's exciting",
+      "timeframe": "e.g. 'In the next few weeks' or 'Over the next 1-2 months'",
+      "signs": ["Early sign to watch for 1", "Early sign 2", "Early sign 3"]
+    }
+  ]
+}
+
+Provide 2 predictions per category (6 total).`;

--- a/lib/ai/types.ts
+++ b/lib/ai/types.ts
@@ -20,3 +20,27 @@ export interface RecommendationItem {
 export interface RecommendationOutput {
   recommendations: RecommendationItem[];
 }
+
+export interface PredictionInput {
+  ageMonths: number;
+  childName: string;
+  milestones: {
+    category: string;
+    name: string;
+    status: string;
+  }[];
+  wordCount: number;
+  phraseCount: number;
+}
+
+export interface PredictionItem {
+  category: string;
+  title: string;
+  description: string;
+  timeframe: string;
+  signs: string[];
+}
+
+export interface PredictionOutput {
+  predictions: PredictionItem[];
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -51,6 +51,7 @@ export const wordLogs = sqliteTable("word_logs", {
     .notNull()
     .references(() => children.id),
   word: text("word").notNull(),
+  type: text("type").notNull().default("word"),
   isPhrase: integer("is_phrase", { mode: "boolean" }).notNull().default(false),
   observedDate: text("observed_date").notNull(),
   createdAt: integer("created_at", { mode: "timestamp" })

--- a/lib/quiz/engine.ts
+++ b/lib/quiz/engine.ts
@@ -4,10 +4,42 @@ import { todayISO } from "@/lib/utils";
 
 import { quizQuestions, type QuizQuestion } from "./questions";
 
+const AGE_BRACKETS = [
+  { min: 2, max: 5 },
+  { min: 6, max: 9 },
+  { min: 9, max: 12 },
+  { min: 12, max: 15 },
+  { min: 15, max: 18 },
+  { min: 18, max: 24 },
+  { min: 24, max: 36 },
+];
+
+function getBracketForAge(ageMonths: number) {
+  return AGE_BRACKETS.find((b) => ageMonths >= b.min && ageMonths <= b.max);
+}
+
 export function getQuestionsForAge(ageMonths: number): QuizQuestion[] {
   return quizQuestions.filter(
     (q) => ageMonths >= q.minMonths && ageMonths <= q.maxMonths
   );
+}
+
+export function getQuestionsForNextBracket(
+  afterMaxMonths: number
+): QuizQuestion[] {
+  const currentIndex = AGE_BRACKETS.findIndex((b) => b.max === afterMaxMonths);
+  if (currentIndex === -1 || currentIndex >= AGE_BRACKETS.length - 1) {
+    return [];
+  }
+  const next = AGE_BRACKETS[currentIndex + 1];
+  return quizQuestions.filter(
+    (q) => q.minMonths === next.min && q.maxMonths === next.max
+  );
+}
+
+export function getBracketMaxForAge(ageMonths: number): number {
+  const bracket = getBracketForAge(ageMonths);
+  return bracket ? bracket.max : AGE_BRACKETS[AGE_BRACKETS.length - 1].max;
 }
 
 export async function processQuizResults(


### PR DESCRIPTION
## Summary
- **Multi-child support**: Dashboard pill switcher to toggle between children, add child button, remove child from settings
- **Communication page**: Renamed Words tab to Comms, split into Words and Gestures sections with age-appropriate suggestions for each
- **Progressive quiz**: Advances through age brackets when all answers are "yes", skips consistently-achieved milestones on retake
- **Motor assessment**: Questionnaire-style assessment replacing tap-to-cycle, tap-to-toggle status on milestone list
- **UI cleanup**: Streamlined bottom nav to 4 tabs (Home, Comms, Motor, Settings), moved Timeline and What's Next to dashboard cards
- **What's Next**: Coming soon placeholder with AI predictions infrastructure preserved for future use
- **Date picker**: Replaced native date input with Month/Day/Year dropdown selects
- **Word management**: Delete words, suggested words by age bracket with multi-select

## Test plan
- [ ] Create account and add a child
- [ ] Complete progressive quiz — verify bracket advancement on all-yes
- [ ] Add a second child, switch between them on dashboard
- [ ] Navigate to Communication tab, switch between Words and Gestures
- [ ] Add words and gestures from suggestions and custom input
- [ ] Delete a word and a gesture
- [ ] Run motor assessment, verify tap-to-toggle on results
- [ ] Retake quiz — verify achieved milestones are skipped
- [ ] Tap Timeline and What's Next cards on dashboard
- [ ] Remove a child from Settings with confirmation
- [ ] Verify bottom nav has 4 tabs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)