### PR TITLE
db: add FK indexes, enum CHECK constraints, length limits

### DIFF
--- a/app/api/children/route.ts
+++ b/app/api/children/route.ts
@@ -4,13 +4,7 @@ import { eq, and } from "drizzle-orm";
 
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-import {
-  children,
-  milestones,
-  wordLogs,
-  quizResponses,
-  recommendations,
-} from "@/lib/db/schema";
+import { children } from "@/lib/db/schema";
 
 const createChildSchema = z.object({
   name: z.string().min(1, "Name is required"),
@@ -85,10 +79,6 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: "Child not found" }, { status: 404 });
     }
 
-    await db.delete(recommendations).where(eq(recommendations.childId, childId));
-    await db.delete(quizResponses).where(eq(quizResponses.childId, childId));
-    await db.delete(wordLogs).where(eq(wordLogs.childId, childId));
-    await db.delete(milestones).where(eq(milestones.childId, childId));
     await db.delete(children).where(eq(children.id, childId));
 
     return NextResponse.json({ data: { success: true } });

--- a/drizzle/0001_milky_gambit.sql
+++ b/drizzle/0001_milky_gambit.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "children" ALTER COLUMN "name" SET DATA TYPE varchar(80);--> statement-breakpoint
+ALTER TABLE "milestones" ALTER COLUMN "name" SET DATA TYPE varchar(200);--> statement-breakpoint
+ALTER TABLE "word_logs" ALTER COLUMN "word" SET DATA TYPE varchar(80);--> statement-breakpoint
+CREATE INDEX "idx_children_user_id" ON "children" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_milestones_child_id" ON "milestones" USING btree ("child_id");--> statement-breakpoint
+CREATE INDEX "idx_quiz_responses_child_id" ON "quiz_responses" USING btree ("child_id");--> statement-breakpoint
+CREATE INDEX "idx_recommendations_child_id" ON "recommendations" USING btree ("child_id");--> statement-breakpoint
+CREATE INDEX "idx_word_logs_child_id" ON "word_logs" USING btree ("child_id");--> statement-breakpoint
+ALTER TABLE "milestones" ADD CONSTRAINT "milestones_status_chk" CHECK (status IN ('not_yet','sometimes','consistently'));--> statement-breakpoint
+ALTER TABLE "milestones" ADD CONSTRAINT "milestones_category_chk" CHECK (category IN ('language','gross_motor','fine_motor'));--> statement-breakpoint
+ALTER TABLE "word_logs" ADD CONSTRAINT "word_logs_type_chk" CHECK (type IN ('word','gesture'));

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,488 @@
+{
+  "id": "fd41eb57-fbee-484d-b4c9-7ee64e34dbf4",
+  "prevId": "0c80d5ef-3c80-4ffb-b512-d05725eafe46",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.children": {
+      "name": "children",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_children_user_id": {
+          "name": "idx_children_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "children_user_id_users_id_fk": {
+          "name": "children_user_id_users_id_fk",
+          "tableFrom": "children",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestones": {
+      "name": "milestones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_yet'"
+        },
+        "observed_date": {
+          "name": "observed_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_milestones_child_id": {
+          "name": "idx_milestones_child_id",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "milestones_child_id_children_id_fk": {
+          "name": "milestones_child_id_children_id_fk",
+          "tableFrom": "milestones",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "milestones_status_chk": {
+          "name": "milestones_status_chk",
+          "value": "status IN ('not_yet','sometimes','consistently')"
+        },
+        "milestones_category_chk": {
+          "name": "milestones_category_chk",
+          "value": "category IN ('language','gross_motor','fine_motor')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quiz_responses": {
+      "name": "quiz_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_quiz_responses_child_id": {
+          "name": "idx_quiz_responses_child_id",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_responses_child_id_children_id_fk": {
+          "name": "quiz_responses_child_id_children_id_fk",
+          "tableFrom": "quiz_responses",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommendations": {
+      "name": "recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "context_snapshot": {
+          "name": "context_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_recommendations_child_id": {
+          "name": "idx_recommendations_child_id",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recommendations_child_id_children_id_fk": {
+          "name": "recommendations_child_id_children_id_fk",
+          "tableFrom": "recommendations",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.word_logs": {
+      "name": "word_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "word": {
+          "name": "word",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'word'"
+        },
+        "is_phrase": {
+          "name": "is_phrase",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "observed_date": {
+          "name": "observed_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_word_logs_child_id": {
+          "name": "idx_word_logs_child_id",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "word_logs_child_id_children_id_fk": {
+          "name": "word_logs_child_id_children_id_fk",
+          "tableFrom": "word_logs",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "word_logs_type_chk": {
+          "name": "word_logs_type_chk",
+          "value": "type IN ('word','gesture')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776517712261,
       "tag": "0000_wise_energizer",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1776581746980,
+      "tag": "0001_milky_gambit",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,9 +1,13 @@
+import { sql } from "drizzle-orm";
 import {
   pgTable,
   uuid,
   text,
+  varchar,
   timestamp,
   boolean,
+  index,
+  check,
 } from "drizzle-orm/pg-core";
 
 export const users = pgTable("users", {
@@ -15,67 +19,100 @@ export const users = pgTable("users", {
     .defaultNow(),
 });
 
-export const children = pgTable("children", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  userId: uuid("user_id")
-    .notNull()
-    .references(() => users.id, { onDelete: "cascade" }),
-  name: text("name").notNull(),
-  dateOfBirth: text("date_of_birth").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: "date" })
-    .notNull()
-    .defaultNow(),
-});
+export const children = pgTable(
+  "children",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    name: varchar("name", { length: 80 }).notNull(),
+    dateOfBirth: text("date_of_birth").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "date" })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [index("idx_children_user_id").on(table.userId)]
+);
 
-export const milestones = pgTable("milestones", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  childId: uuid("child_id")
-    .notNull()
-    .references(() => children.id, { onDelete: "cascade" }),
-  category: text("category").notNull(),
-  name: text("name").notNull(),
-  status: text("status").notNull().default("not_yet"),
-  observedDate: text("observed_date"),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: "date" })
-    .notNull()
-    .defaultNow(),
-});
+export const milestones = pgTable(
+  "milestones",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    childId: uuid("child_id")
+      .notNull()
+      .references(() => children.id, { onDelete: "cascade" }),
+    category: text("category").notNull(),
+    name: varchar("name", { length: 200 }).notNull(),
+    status: text("status").notNull().default("not_yet"),
+    observedDate: text("observed_date"),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "date" })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_milestones_child_id").on(table.childId),
+    check(
+      "milestones_status_chk",
+      sql`status IN ('not_yet','sometimes','consistently')`
+    ),
+    check(
+      "milestones_category_chk",
+      sql`category IN ('language','gross_motor','fine_motor')`
+    ),
+  ]
+);
 
-export const wordLogs = pgTable("word_logs", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  childId: uuid("child_id")
-    .notNull()
-    .references(() => children.id, { onDelete: "cascade" }),
-  word: text("word").notNull(),
-  type: text("type").notNull().default("word"),
-  isPhrase: boolean("is_phrase").notNull().default(false),
-  observedDate: text("observed_date").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: "date" })
-    .notNull()
-    .defaultNow(),
-});
+export const wordLogs = pgTable(
+  "word_logs",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    childId: uuid("child_id")
+      .notNull()
+      .references(() => children.id, { onDelete: "cascade" }),
+    word: varchar("word", { length: 80 }).notNull(),
+    type: text("type").notNull().default("word"),
+    isPhrase: boolean("is_phrase").notNull().default(false),
+    observedDate: text("observed_date").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "date" })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_word_logs_child_id").on(table.childId),
+    check("word_logs_type_chk", sql`type IN ('word','gesture')`),
+  ]
+);
 
-export const quizResponses = pgTable("quiz_responses", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  childId: uuid("child_id")
-    .notNull()
-    .references(() => children.id, { onDelete: "cascade" }),
-  questionId: text("question_id").notNull(),
-  answer: text("answer").notNull(),
-  completedAt: timestamp("completed_at", { withTimezone: true, mode: "date" })
-    .notNull()
-    .defaultNow(),
-});
+export const quizResponses = pgTable(
+  "quiz_responses",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    childId: uuid("child_id")
+      .notNull()
+      .references(() => children.id, { onDelete: "cascade" }),
+    questionId: text("question_id").notNull(),
+    answer: text("answer").notNull(),
+    completedAt: timestamp("completed_at", { withTimezone: true, mode: "date" })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [index("idx_quiz_responses_child_id").on(table.childId)]
+);
 
-export const recommendations = pgTable("recommendations", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  childId: uuid("child_id")
-    .notNull()
-    .references(() => children.id, { onDelete: "cascade" }),
-  category: text("category").notNull(),
-  content: text("content").notNull(),
-  generatedAt: timestamp("generated_at", { withTimezone: true, mode: "date" })
-    .notNull()
-    .defaultNow(),
-  contextSnapshot: text("context_snapshot"),
-});
+export const recommendations = pgTable(
+  "recommendations",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    childId: uuid("child_id")
+      .notNull()
+      .references(() => children.id, { onDelete: "cascade" }),
+    category: text("category").notNull(),
+    content: text("content").notNull(),
+    generatedAt: timestamp("generated_at", { withTimezone: true, mode: "date" })
+      .notNull()
+      .defaultNow(),
+    contextSnapshot: text("context_snapshot"),
+  },
+  (table) => [index("idx_recommendations_child_id").on(table.childId)]
+);


### PR DESCRIPTION
## Summary
- FK indexes on every child-scoped column (closes #3)
- CHECK constraints for status/category/type enums (closes #12)
- Length limits on user text columns (closes #27)
- DELETE /api/children no longer needs manual cascade (FK cascade was already in place from prior Postgres migration — closes #4 retroactively)

## Migration
`drizzle/0001_milky_gambit.sql` — clean ADD INDEX / ADD CONSTRAINT statements, no DROP/RECREATE. Apply via `npx drizzle-kit push` against your Postgres instance.

## Notes
The plan assumed SQLite. The codebase migrated to Postgres in commit 14d31e5 — primer needs updating in a follow-up.

## Test plan
- [ ] DELETE a child via /api/children — related rows in milestones/word_logs/quiz_responses/recommendations gone
- [ ] Insert milestone with status='bogus' — DB rejects (CHECK)
- [ ] Insert wordLogs with type='weird' — DB rejects (CHECK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)