### PR TITLE
chore: sort toggle, gesture stat split, agent primer

### DIFF
--- a/app/(app)/children/[childId]/language/page.tsx
+++ b/app/(app)/children/[childId]/language/page.tsx
@@ -15,6 +15,7 @@ interface WordEntry {
 }
 
 type TabType = "words" | "gestures";
+type SortType = "date" | "alpha";
 
 const suggestedWords: { minMonths: number; maxMonths: number; words: string[] }[] = [
   { minMonths: 0, maxMonths: 5, words: ["mama", "dada", "baba"] },
@@ -34,14 +35,41 @@ const suggestedGestures: { minMonths: number; maxMonths: number; gestures: strin
   { minMonths: 24, maxMonths: 36, gestures: ["holding up fingers for age", "hugging dolls/stuffed animals", "taking turns in games"] },
 ];
 
-function getSuggestionsForAge(ageMonths: number): string[] {
-  const bracket = suggestedWords.find((b) => ageMonths >= b.minMonths && ageMonths <= b.maxMonths);
-  return bracket?.words ?? suggestedWords[suggestedWords.length - 1].words;
-}
+const MIN_SUGGESTIONS = 20;
 
-function getGesturesForAge(ageMonths: number): string[] {
-  const bracket = suggestedGestures.find((b) => ageMonths >= b.minMonths && ageMonths <= b.maxMonths);
-  return bracket?.gestures ?? suggestedGestures[suggestedGestures.length - 1].gestures;
+function buildSuggestions(
+  brackets: { minMonths: number; maxMonths: number; items: string[] }[],
+  ageMonths: number,
+  excluded: Set<string>,
+  minCount: number
+): string[] {
+  const currentIdx = brackets.findIndex(
+    (b) => ageMonths >= b.minMonths && ageMonths <= b.maxMonths
+  );
+  const startIdx = currentIdx === -1 ? brackets.length - 1 : currentIdx;
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  const tryAdd = (idx: number) => {
+    if (idx < 0 || idx >= brackets.length) return;
+    for (const item of brackets[idx].items) {
+      const key = item.toLowerCase();
+      if (seen.has(key) || excluded.has(key)) continue;
+      seen.add(key);
+      result.push(item);
+    }
+  };
+
+  // Always include current bracket first.
+  tryAdd(startIdx);
+  // Expand outward (younger first, then older) until we hit minCount.
+  for (let offset = 1; result.length < minCount && offset < brackets.length; offset++) {
+    tryAdd(startIdx - offset);
+    if (result.length >= minCount) break;
+    tryAdd(startIdx + offset);
+  }
+
+  return result;
 }
 
 export default function LanguagePage() {
@@ -50,6 +78,7 @@ export default function LanguagePage() {
   const childId = params.childId as string;
 
   const [activeTab, setActiveTab] = useState<TabType>("words");
+  const [sortBy, setSortBy] = useState<SortType>("date");
   const [words, setWords] = useState<WordEntry[]>([]);
   const [gestures, setGestures] = useState<WordEntry[]>([]);
   const [ageMonths, setAgeMonths] = useState(12);
@@ -57,6 +86,7 @@ export default function LanguagePage() {
   const [showModal, setShowModal] = useState(false);
   const [newWord, setNewWord] = useState("");
   const [selectedSuggestions, setSelectedSuggestions] = useState<Set<string>>(new Set());
+  const [recentlyAdded, setRecentlyAdded] = useState<string[]>([]);
   const [isPhrase, setIsPhrase] = useState(false);
   const [observedDate, setObservedDate] = useState(
     new Date().toISOString().split("T")[0]
@@ -141,14 +171,25 @@ export default function LanguagePage() {
 
     setNewWord("");
     setSelectedSuggestions(new Set());
-    setIsPhrase(false);
-    setShowModal(false);
+    setRecentlyAdded((prev) => [...itemsToAdd, ...prev]);
     setSubmitting(false);
     await fetchAll();
     router.refresh();
   }
 
+  function closeModal() {
+    setShowModal(false);
+    setNewWord("");
+    setSelectedSuggestions(new Set());
+    setIsPhrase(false);
+    setRecentlyAdded([]);
+  }
+
   const currentItems = activeTab === "words" ? words : gestures;
+  const trimmedNewWord = newWord.trim().toLowerCase();
+  const isDuplicate =
+    trimmedNewWord.length > 0 &&
+    currentItems.some((w) => w.word.toLowerCase() === trimmedNewWord);
   const wordCount = words.filter((w) => !w.isPhrase).length;
   const phraseCount = words.filter((w) => w.isPhrase).length;
   const gestureCount = gestures.length;
@@ -166,9 +207,20 @@ export default function LanguagePage() {
 
   const sortedMonths = Object.keys(grouped).sort().reverse();
 
+  const excluded = new Set(currentItems.map((w) => w.word.toLowerCase()));
   const suggestions = activeTab === "words"
-    ? getSuggestionsForAge(ageMonths).filter((s) => !words.some((w) => w.word.toLowerCase() === s.toLowerCase()))
-    : getGesturesForAge(ageMonths).filter((s) => !gestures.some((g) => g.word.toLowerCase() === s.toLowerCase()));
+    ? buildSuggestions(
+        suggestedWords.map((b) => ({ minMonths: b.minMonths, maxMonths: b.maxMonths, items: b.words })),
+        ageMonths,
+        excluded,
+        MIN_SUGGESTIONS
+      )
+    : buildSuggestions(
+        suggestedGestures.map((b) => ({ minMonths: b.minMonths, maxMonths: b.maxMonths, items: b.gestures })),
+        ageMonths,
+        excluded,
+        MIN_SUGGESTIONS
+      );
 
   return (
     <main className="min-h-dvh px-6 pt-8 pb-24">
@@ -190,6 +242,7 @@ export default function LanguagePage() {
             onClick={() => {
               setSelectedSuggestions(new Set());
               setNewWord("");
+              setRecentlyAdded([]);
               setShowModal(true);
             }}
             className="w-11 h-11 rounded-full bg-terracotta text-white flex items-center justify-center text-xl shadow-[var(--shadow-button)] hover:bg-terracotta-dark transition-all duration-200 cursor-pointer"
@@ -237,6 +290,33 @@ export default function LanguagePage() {
           )}
         </div>
 
+        {/* Sort toggle */}
+        {currentItems.length > 0 && (
+          <div className="flex items-center justify-end gap-1 mb-3">
+            <span className="text-xs text-olive-light mr-1">Sort:</span>
+            <button
+              onClick={() => setSortBy("date")}
+              className={`rounded-full px-2.5 py-1 text-xs font-semibold transition-all duration-200 cursor-pointer ${
+                sortBy === "date"
+                  ? "bg-sand-light text-olive-dark"
+                  : "text-olive-muted hover:text-olive-dark"
+              }`}
+            >
+              Date
+            </button>
+            <button
+              onClick={() => setSortBy("alpha")}
+              className={`rounded-full px-2.5 py-1 text-xs font-semibold transition-all duration-200 cursor-pointer ${
+                sortBy === "alpha"
+                  ? "bg-sand-light text-olive-dark"
+                  : "text-olive-muted hover:text-olive-dark"
+              }`}
+            >
+              A–Z
+            </button>
+          </div>
+        )}
+
         {/* Item list */}
         {loading ? (
           <p className="text-olive-muted text-center">Loading...</p>
@@ -248,6 +328,43 @@ export default function LanguagePage() {
             <p className="text-olive-light text-sm">
               Tap + to add your child&apos;s first {activeTab === "words" ? "word" : "gesture"}
             </p>
+          </div>
+        ) : sortBy === "alpha" ? (
+          <div>
+            {[...currentItems]
+              .sort((a, b) => a.word.toLowerCase().localeCompare(b.word.toLowerCase()))
+              .map((w) => (
+                <div
+                  key={w.id}
+                  className="flex items-center justify-between py-3 border-b border-sand-light last:border-0 group"
+                >
+                  <div className="flex items-center gap-2 flex-1 min-w-0">
+                    {w.isPhrase && (
+                      <span className="text-xs bg-lang-bg text-lang rounded-full px-2 py-0.5 font-semibold shrink-0">
+                        phrase
+                      </span>
+                    )}
+                    <span className="text-olive-dark font-medium truncate">
+                      {w.isPhrase ? `"${w.word}"` : w.word}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <span className="text-xs text-olive-muted">
+                      {new Date(w.observedDate + "T00:00:00").toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                      })}
+                    </span>
+                    <button
+                      onClick={() => handleDelete(w.id)}
+                      className="w-6 h-6 rounded-full text-olive-light hover:bg-red-50 hover:text-red-500 flex items-center justify-center text-sm transition-colors duration-200 cursor-pointer"
+                      title="Remove"
+                    >
+                      x
+                    </button>
+                  </div>
+                </div>
+              ))}
           </div>
         ) : (
           sortedMonths.map((month) => {
@@ -304,13 +421,33 @@ export default function LanguagePage() {
         <div className="fixed inset-0 z-50 flex items-end justify-center">
           <div
             className="absolute inset-0 bg-black/30 backdrop-blur-sm"
-            onClick={() => setShowModal(false)}
+            onClick={closeModal}
           />
           <div className="relative w-full max-w-sm bg-warm-white rounded-t-[24px] p-6 pb-[calc(1.5rem+env(safe-area-inset-bottom))]">
             <div className="w-10 h-1 bg-sand rounded-full mx-auto mb-4" />
             <h2 className="font-[family-name:var(--font-heading)] text-2xl text-olive-dark mb-4">
               Add {activeTab === "words" ? "a word" : "a gesture"}
             </h2>
+
+            {/* Recently added in this session */}
+            {recentlyAdded.length > 0 && (
+              <div className="mb-4 rounded-[var(--radius-input)] bg-lang-bg/40 px-3 py-2.5">
+                <p className="text-xs font-bold text-olive-light uppercase tracking-wider mb-1.5">
+                  Added ({recentlyAdded.length})
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  {recentlyAdded.map((item, i) => (
+                    <span
+                      key={`${item}-${i}`}
+                      className="rounded-full bg-warm-white px-2.5 py-0.5 text-xs font-medium text-olive-dark"
+                    >
+                      {item}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
             <form onSubmit={handleAdd} className="flex flex-col gap-4">
               {/* Suggested items */}
               {(activeTab === "gestures" || !isPhrase) && suggestions.length > 0 && (
@@ -337,19 +474,30 @@ export default function LanguagePage() {
                 </div>
               )}
 
-              <input
-                type="text"
-                value={newWord}
-                onChange={(e) => setNewWord(e.target.value)}
-                placeholder={
-                  activeTab === "gestures"
-                    ? "Or type a custom gesture..."
-                    : isPhrase
-                      ? '"more milk"'
-                      : "Or type a custom word..."
-                }
-                className="w-full rounded-[var(--radius-input)] border border-sand-light bg-cream px-4 py-3 text-olive-dark placeholder:text-olive-light focus:border-terracotta focus:outline-none focus:ring-2 focus:ring-terracotta/20"
-              />
+              <div>
+                <input
+                  type="text"
+                  value={newWord}
+                  onChange={(e) => setNewWord(e.target.value)}
+                  placeholder={
+                    activeTab === "gestures"
+                      ? "Or type a custom gesture..."
+                      : isPhrase
+                        ? '"more milk"'
+                        : "Or type a custom word..."
+                  }
+                  className={`w-full rounded-[var(--radius-input)] border bg-cream px-4 py-3 text-olive-dark placeholder:text-olive-light focus:outline-none focus:ring-2 ${
+                    isDuplicate
+                      ? "border-amber-400 focus:border-amber-500 focus:ring-amber-500/20"
+                      : "border-sand-light focus:border-terracotta focus:ring-terracotta/20"
+                  }`}
+                />
+                {isDuplicate && (
+                  <p className="mt-1.5 text-xs text-amber-700">
+                    &ldquo;{newWord.trim()}&rdquo; is already on the list.
+                  </p>
+                )}
+              </div>
 
               <div className="flex items-center gap-3">
                 {activeTab === "words" && (
@@ -377,17 +525,34 @@ export default function LanguagePage() {
                 />
               </div>
 
-              <button
-                type="submit"
-                disabled={submitting || (selectedSuggestions.size === 0 && !newWord.trim())}
-                className="w-full rounded-[var(--radius-button)] bg-terracotta px-6 py-4 font-semibold text-white shadow-[var(--shadow-button)] transition-all duration-200 hover:bg-terracotta-dark disabled:opacity-50 cursor-pointer min-h-[52px]"
-              >
-                {submitting
-                  ? "Adding..."
-                  : selectedSuggestions.size > 0
-                    ? `Add ${selectedSuggestions.size + (newWord.trim() ? 1 : 0)} ${activeTab === "words" ? "word" : "gesture"}${selectedSuggestions.size + (newWord.trim() ? 1 : 0) !== 1 ? "s" : ""}`
-                    : "Add"}
-              </button>
+              <div className="flex gap-2">
+                {recentlyAdded.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={closeModal}
+                    className="flex-1 rounded-[var(--radius-button)] border-2 border-sand-light bg-warm-white px-4 py-4 font-semibold text-olive-dark transition-all duration-200 hover:bg-sand-light cursor-pointer min-h-[52px]"
+                  >
+                    Done
+                  </button>
+                )}
+                <button
+                  type="submit"
+                  disabled={
+                    submitting ||
+                    (selectedSuggestions.size === 0 && !newWord.trim()) ||
+                    isDuplicate
+                  }
+                  className="flex-1 rounded-[var(--radius-button)] bg-terracotta px-6 py-4 font-semibold text-white shadow-[var(--shadow-button)] transition-all duration-200 hover:bg-terracotta-dark disabled:opacity-50 cursor-pointer min-h-[52px]"
+                >
+                  {submitting
+                    ? "Adding..."
+                    : selectedSuggestions.size > 0
+                      ? `Add ${selectedSuggestions.size + (newWord.trim() ? 1 : 0)}`
+                      : recentlyAdded.length > 0
+                        ? "Add another"
+                        : "Add"}
+                </button>
+              </div>
             </form>
           </div>
         </div>

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -144,6 +144,7 @@ export default async function DashboardPage({
             <p className="text-sm text-olive-muted ml-12">
               {wordStats.wordCount} word{wordStats.wordCount !== 1 ? "s" : ""}
               {wordStats.phraseCount > 0 && ` · ${wordStats.phraseCount} phrase${wordStats.phraseCount !== 1 ? "s" : ""}`}
+              {wordStats.gestureCount > 0 && ` · ${wordStats.gestureCount} gesture${wordStats.gestureCount !== 1 ? "s" : ""}`}
             </p>
             {categorySummaries.language && (
               <div className="ml-12 mt-2">

--- a/lib/queries/milestones.ts
+++ b/lib/queries/milestones.ts
@@ -50,18 +50,37 @@ export async function getWordStats(childId: string) {
   const [words] = await db
     .select({ count: sql<number>`count(*)::int` })
     .from(wordLogs)
-    .where(and(eq(wordLogs.childId, childId), eq(wordLogs.isPhrase, false)))
+    .where(
+      and(
+        eq(wordLogs.childId, childId),
+        eq(wordLogs.type, "word"),
+        eq(wordLogs.isPhrase, false)
+      )
+    )
     .limit(1);
 
   const [phrases] = await db
     .select({ count: sql<number>`count(*)::int` })
     .from(wordLogs)
-    .where(and(eq(wordLogs.childId, childId), eq(wordLogs.isPhrase, true)))
+    .where(
+      and(
+        eq(wordLogs.childId, childId),
+        eq(wordLogs.type, "word"),
+        eq(wordLogs.isPhrase, true)
+      )
+    )
+    .limit(1);
+
+  const [gestures] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(wordLogs)
+    .where(and(eq(wordLogs.childId, childId), eq(wordLogs.type, "gesture")))
     .limit(1);
 
   return {
     wordCount: words?.count ?? 0,
     phraseCount: phrases?.count ?? 0,
+    gestureCount: gestures?.count ?? 0,
   };
 }
 

--- a/primer.md
+++ b/primer.md
@@ -1,0 +1,157 @@
+# Totter — Agent Primer
+
+**Read this first.** Every new Claude agent picking up work on this repo should load this file before doing anything else. It is the canonical orientation document.
+
+---
+
+## What is Totter?
+
+Totter is a child developmental milestone tracking app. Parents log words, gestures, motor milestones, and quiz responses for one or more children. The app shows progress dashboards, a chronological timeline, and (eventually) AI-generated tips and predictions.
+
+Repo: `shymcf/emmys-milestones` (default branch `main`).
+Live owner: Drew McFarland.
+
+---
+
+## Stack
+
+- **Next.js 16** (App Router only — no Pages Router)
+- **React 19**
+- **TypeScript** strict mode (no `any`)
+- **Tailwind CSS v4** (utility classes; no CSS modules / styled-components)
+- **Drizzle ORM** + **libsql** (SQLite, file-based — `totter.db` in repo root)
+- **NextAuth v5 beta** with Credentials provider (bcryptjs hashed passwords, JWT sessions)
+- **Anthropic SDK** (Claude Haiku) — currently disabled, on the back burner
+
+---
+
+## Repo layout
+
+```
+app/
+  (app)/                       protected routes; layout redirects unauth users
+    children/[childId]/
+      language/                Words + Gestures (a.k.a. "Communication")
+      motor/[category]/        gross_motor or fine_motor
+      quiz/                    interactive milestone quiz
+      timeline/                chronological log
+      recommendations/         AI tips (back burner)
+      predictions/             AI predictions (back burner — shows "Coming Soon")
+    children/new/              add child form
+    dashboard/                 main dashboard (server component)
+    settings/                  manage children, retake quizzes, logout
+  api/
+    auth/                      signup + NextAuth handler
+    children/                  GET/POST/DELETE children
+    children/[childId]/        nested resources (milestones, words, quiz, etc.)
+  login/, signup/              public auth pages
+components/                    shared UI (currently just BottomNav)
+lib/
+  db/                          Drizzle schema + client
+  auth.ts                      NextAuth config
+  queries/                     reusable DB query functions
+  quiz/                        quiz engine + question bank
+  milestones/                  age-bracket checklist
+  ai/                          Claude client + prompts (back burner)
+  utils.ts                     date helpers, age formatting
+```
+
+---
+
+## Coding standards
+
+### TypeScript
+- Strict mode. **No `any`**. No `as` casts unless absolutely necessary.
+- `async/await`, never `.then()` chains.
+- Named exports, except for page/layout components (Next.js requires default exports there).
+- Import order: stdlib → external packages → internal modules, separated by blank lines.
+
+### React / Next.js
+- App Router only.
+- Server components by default. `"use client"` only for interactivity, hooks, or browser APIs.
+- API route handlers use `NextRequest`/`NextResponse`.
+- No separate backend servers.
+
+### Tailwind
+- Utility classes inline. Use CSS custom properties (`var(--...)`) for theming tokens.
+- Mobile-first; design fits inside a `max-w-sm` mobile shell.
+
+### General
+- No over-abstraction. Inline logic until a pattern repeats 3+ times.
+- Server-side env vars only — never reference `process.env` in client components.
+- Keep CLAUDE.md (workspace) and `primer.md` (this file) in sync.
+
+---
+
+## Auth pattern
+
+Every protected API route under `/api/children/[childId]/*` must:
+1. `await auth()` and check `session?.user?.id` → 401 if missing.
+2. Look up the child and verify `child.userId === session.user.id` → 404 if not.
+
+**This pattern is currently duplicated across 8 routes.** A backlog issue (`refactor: extract auth + child-ownership guard`) tracks consolidating it into `lib/auth-guard.ts`.
+
+---
+
+## Database
+
+- SQLite file `totter.db` at repo root.
+- Schema in `lib/db/schema.ts`. Tables: `users`, `children`, `milestones`, `wordLogs`, `quizResponses`, `recommendations`.
+- Apply schema changes with `npx drizzle-kit push`.
+- Dates stored as `text` in `YYYY-MM-DD` format (not native DATE).
+- Foreign keys exist via `.references()` but **no `onDelete: "cascade"` is configured** — cascade is done manually in `/api/children` DELETE.
+
+---
+
+## Backlog policy (READ THIS)
+
+**Every feature, bug, refactor, or future work item discussed in conversation MUST be logged as a GitHub issue in the `shymcf/emmys-milestones` repo before the conversation ends.**
+
+Rules:
+1. **Format**: Gherkin-style acceptance criteria in the issue body (`Feature:`, `Scenario:`, `Given/When/Then`).
+2. **Labels**: apply at least one of `feature`, `bug`, `refactor`, `tech-debt`, `accessibility`, `performance`, `schema`, `ux`, `dx`, `ai-backburner`.
+3. **Priority**: also apply `priority:critical`, `priority:high`, `priority:medium`, or `priority:low`.
+4. **AI features**: any AI-related work (recommendations, predictions, prompt changes) is `ai-backburner` and `priority:low` — it is NOT to be worked on right now.
+5. **Tool**: use `gh issue create` (or `gh issue list` first to avoid duplicates).
+6. **Title prefix**: `feat:`, `fix:`, `refactor:`, `chore:`, `a11y:`, `perf:` — match conventional commit style.
+7. **Acknowledge in chat**: when you log an issue, mention `→ logged as #N` so the user sees it.
+
+If the user mentions a future feature in passing — e.g. "we'll add X later" — log it. If they describe a bug they noticed, log it. If a refactor opportunity comes up while reading code, log it. Do NOT silently let backlog items disappear.
+
+---
+
+## Working on a worktree
+
+This project uses Claude worktrees under `.claude/worktrees/<name>/`. The worktree is a full checkout on its own branch (`claude/<name>`). Commits there will be merged back via PR. Always operate from the worktree path the user is in — do not `cd` into the parent repo.
+
+---
+
+## Things to avoid
+
+- Don't install packages that duplicate existing capability.
+- No Prisma — use Drizzle.
+- No icon libraries — use inline SVG.
+- Don't write tests unless explicitly asked.
+- Don't create README.md or docs unless explicitly asked.
+- Don't work on AI features right now (back burner).
+- Drew is non-technical — explain options in plain language with their implications.
+
+---
+
+## Useful commands
+
+```bash
+# Apply schema changes
+npx drizzle-kit push
+
+# Start dev
+npm run dev
+
+# Lint / typecheck
+npm run lint
+npx tsc --noEmit
+
+# GitHub
+gh issue list --label refactor
+gh issue create --title "..." --body "..." --label refactor,priority:high
+```

--- a/primer.md
+++ b/primer.md
@@ -19,7 +19,7 @@ Live owner: Drew McFarland.
 - **React 19**
 - **TypeScript** strict mode (no `any`)
 - **Tailwind CSS v4** (utility classes; no CSS modules / styled-components)
-- **Drizzle ORM** + **libsql** (SQLite, file-based — `totter.db` in repo root)
+- **Drizzle ORM** + **node-postgres** (Postgres — connection via `DATABASE_URL`). Note: the repo originally used SQLite (`totter.db`); migrated to Postgres in commit `14d31e5`. The `totter.db` file is a stale artifact and can be ignored.
 - **NextAuth v5 beta** with Credentials provider (bcryptjs hashed passwords, JWT sessions)
 - **Anthropic SDK** (Claude Haiku) — currently disabled, on the back burner
 
@@ -95,11 +95,11 @@ Every protected API route under `/api/children/[childId]/*` must:
 
 ## Database
 
-- SQLite file `totter.db` at repo root.
-- Schema in `lib/db/schema.ts`. Tables: `users`, `children`, `milestones`, `wordLogs`, `quizResponses`, `recommendations`.
-- Apply schema changes with `npx drizzle-kit push`.
-- Dates stored as `text` in `YYYY-MM-DD` format (not native DATE).
-- Foreign keys exist via `.references()` but **no `onDelete: "cascade"` is configured** — cascade is done manually in `/api/children` DELETE.
+- Postgres via `node-postgres`; connection string in `DATABASE_URL`.
+- Schema in `lib/db/schema.ts` (`pg-core`). Tables: `users`, `children`, `milestones`, `wordLogs`, `quizResponses`, `recommendations`.
+- Apply schema changes with `npx drizzle-kit push` (or `generate` then `migrate` for explicit migrations).
+- Dates stored as `text` in `YYYY-MM-DD` format (helpers `parseDateOnly` / `formatDateOnly` in `lib/utils.ts`).
+- All child-scoped FKs use `onDelete: "cascade"`. Cascade is automatic — DELETE handlers should NOT manually delete children rows.
 
 ---
 


### PR DESCRIPTION
## Summary
The in-flight UX work + the new agent primer doc.

- Language page: Date / A-Z sort toggle + sticky modal multi-add + duplicate detection + adjacent-bracket suggestion expansion (target 20 visible)
- Dashboard: Language card now shows separate word/phrase/gesture counts
- getWordStats: filter by type so gestures stop being counted as words
- **primer.md** (new): canonical agent orientation doc + GitHub-issue backlog policy. Every new agent should read this first.

## Test plan
- [ ] /children/X/language: tab between Words and Gestures, sort toggle persists, modal stays open and warns on duplicates
- [ ] /dashboard: Language card shows "N words · N phrases · N gestures"

🤖 Generated with [Claude Code](https://claude.com/claude-code)